### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ksusonic/nitask/security/code-scanning/2](https://github.com/ksusonic/nitask/security/code-scanning/2)

To fix the problem, explicitly add a `permissions` block to the workflow root (at the top level, beneath the `name` definition and before `on:`), setting the minimum privilege necessary for the workflow to execute. Since the shown workflow includes only code checkout, building, and testing, it does not appear to require any write permissions. The minimal safe permission for such workflows is `contents: read`, which allows the workflow to fetch code but not make changes to the repository or other resources. The fix involves adding the following YAML block:

```yaml
permissions:
  contents: read
```

Insert this block after `name: Go` and before the `on:` block in `.github/workflows/go.yml`. No imports or other method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
